### PR TITLE
Only replace spaces with nbsp in text nodes

### DIFF
--- a/lib/mobiledoc/renderers/0.2.rb
+++ b/lib/mobiledoc/renderers/0.2.rb
@@ -7,6 +7,7 @@ require "mobiledoc/error"
 module Mobiledoc
   class Renderer_0_2
     MOBILEDOC_VERSIONS = ['0.2.0']
+    NBSP = Nokogiri::HTML('&nbsp;').text
 
     include Mobiledoc::Utils::SectionTypes
     include Mobiledoc::Utils::TagNames
@@ -43,7 +44,7 @@ module Mobiledoc
         end
       end
 
-      root.to_html(save_with: 0).gsub('  ', ' &nbsp;')
+      root.to_html(save_with: 0)
     end
 
     def create_document_fragment
@@ -60,7 +61,7 @@ module Mobiledoc
     end
 
     def create_text_node(text)
-      Nokogiri::XML::Text.new(text, doc)
+      Nokogiri::XML::Text.new(text.gsub('  ', " #{NBSP}"), doc)
     end
 
     def create_element_from_marker_type(tag_name='', attributes=[])

--- a/spec/0.2_spec.rb
+++ b/spec/0.2_spec.rb
@@ -440,7 +440,7 @@ module ZeroTwoZero
 
       rendered = render(mobiledoc)
 
-      sn = ' &nbsp;'
+      sn = " #{Nokogiri::HTML('&nbsp;').text}"
       expected_text = [ sn * 2, 'some', sn * 2, space, 'text', sn * 3 ].join
 
       expect(rendered).to eq("<div><p>#{expected_text}</p></div>")

--- a/spec/0.3_spec.rb
+++ b/spec/0.3_spec.rb
@@ -453,10 +453,43 @@ module ZeroThreeZero
 
       rendered = render(mobiledoc)
 
-      sn = ' &nbsp;'
+      sn = " #{Nokogiri::HTML('&nbsp;').text}"
       expected_text = [ sn * 2, 'some', sn * 2, space, 'text', sn * 3 ].join
 
       expect(rendered).to eq("<div><p>#{expected_text}</p></div>")
+    end
+
+    it 'spaces within cards are not converted to nbsps' do
+      card = Module.new do
+        module_function
+
+        def name
+          'space-card'
+        end
+
+        def type
+          'html'
+        end
+
+        def render(env, payload, options)
+          '   '
+        end
+      end
+
+      mobiledoc = {
+        'version' => MOBILEDOC_VERSION,
+        'atoms' => [],
+        'cards' => [
+          ['space-card', {}]
+        ],
+        'markups' => [],
+        'sections' => [
+          [CARD_SECTION_TYPE, 0]
+        ]
+      }
+      rendered = Mobiledoc::HTMLRenderer.new(cards: [card]).render(mobiledoc)
+
+      expect(rendered).to eq('<div><div>   </div></div>')
     end
 
     it 'throws when given an unexpected mobiledoc version' do


### PR DESCRIPTION
Replacing spaces with nbsp in the entire document can cause issues where unwanted nbsps are added to rendered cards and atoms.

With this change the renderer only replaces spaces with nbsp in text nodes.