### PR TITLE
Support 0.3.2 documents

### DIFF
--- a/lib/mobiledoc/renderers/0.2.rb
+++ b/lib/mobiledoc/renderers/0.2.rb
@@ -56,6 +56,12 @@ module Mobiledoc
       Nokogiri::XML::Node.new(tag_name, doc)
     end
 
+    def set_attributes(element, attributes)
+      attributes.each_slice(2) do |prop_name, prop_value|
+        set_attribute(element, prop_name, prop_value)
+      end
+    end
+
     def set_attribute(element, prop_name, prop_value)
       element.set_attribute(prop_name, prop_value)
     end
@@ -66,10 +72,7 @@ module Mobiledoc
 
     def create_element_from_marker_type(tag_name='', attributes=[])
       element = create_element(tag_name)
-
-      attributes.each_slice(2) do |prop_name, prop_value|
-        set_attribute(element, prop_name, prop_value)
-      end
+      set_attributes(element, attributes)
 
       element
     end

--- a/lib/mobiledoc/renderers/0.3.rb
+++ b/lib/mobiledoc/renderers/0.3.rb
@@ -4,7 +4,7 @@ require "mobiledoc/error"
 
 module Mobiledoc
   class Renderer_0_3 < Renderer_0_2
-    MOBILEDOC_VERSIONS = ['0.3.0', '0.3.1']
+    MOBILEDOC_VERSIONS = ['0.3.0', '0.3.1', '0.3.2']
 
     include Mobiledoc::Utils::MarkerTypes
 
@@ -25,6 +25,13 @@ module Mobiledoc
       self.card_options = state[:card_options]
       self.unknown_card_handler = state[:unknown_card_handler]
       self.unknown_atom_handler = state[:unknown_atom_handler]
+    end
+
+    def render_markup_section(type, tag_name, markers, attributes = [])
+      element = super(type, tag_name, markers)
+      set_attributes(element, attributes)
+
+      element
     end
 
     def render_card_section(type, index)

--- a/lib/mobiledoc_html_renderer.rb
+++ b/lib/mobiledoc_html_renderer.rb
@@ -66,9 +66,9 @@ module Mobiledoc
       version = mobiledoc['version']
 
       case version
-      when '0.2.0'
+      when *Renderer_0_2::MOBILEDOC_VERSIONS
         Renderer_0_2.new(mobiledoc, state).render
-      when '0.3.0', '0.3.1', nil
+      when *Renderer_0_3::MOBILEDOC_VERSIONS, nil
         Renderer_0_3.new(mobiledoc, state).render
       else
         raise Mobiledoc::Error.new(%Q[Unexpected Mobiledoc version "#{version}"])

--- a/spec/0.3_spec.rb
+++ b/spec/0.3_spec.rb
@@ -784,5 +784,26 @@ module ZeroThreeZero
         expect(rendered).to eq('<div><aside><code>hello world</code></aside></div>')
       end
     end
+
+    context '0.3.2' do
+      it 'renders 0.3.2 markup section attributes' do
+        mobiledoc = {
+          'version' => '0.3.2',
+          'atoms' => [],
+          'cards' => [],
+          'markups' => [],
+          'sections' => [
+            [MARKUP_SECTION_TYPE, 'P', [
+              [MARKUP_MARKER_TYPE, [], 0, 'hello world']],
+              ['data-md-text-align', 'center']
+            ]
+          ]
+        }
+
+        rendered = render(mobiledoc)
+
+        expect(rendered).to eq('<div><p data-md-text-align="center">hello world</p></div>')
+      end
+    end
   end
 end


### PR DESCRIPTION
Relevant change in the js renderer: https://github.com/bustle/mobiledoc-dom-renderer/commit/b4c48abd96ae7652f7a1f3d043976d2f8c8c6782